### PR TITLE
fix: link to repeat_hello_world_lib properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(repeat_hello_world_lib LANGUAGES C)
 
 include(FetchContent)
 
+# \/ === ADD ALL GITHUB PROJECT DEPENDENCIES HERE === \/
 FetchContent_Declare(
     print_hello_world
     GIT_REPOSITORY https://github.com/Mouse-Unit-07/software-hello-world.git
@@ -16,17 +17,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(print_hello_world)
 
-# empty static library to start
 add_library(repeat_hello_world_lib STATIC)
 
-# ADD ALL SRC SUBDIRECTORIES HERE
+# \/ === ADD SOURCE SUBDIRECTORIES HERE === \/
 add_subdirectory(repeat_hello_world)
-
 target_include_directories(repeat_hello_world_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/repeat_hello_world
 )
 
-# Link to real implementation for production
+# \/ === LINK TO GITHUB DEPENDENCIES HERE === \/
 target_link_libraries(repeat_hello_world_lib PUBLIC
-    print_hello_world
+    hello_world_lib
 )

--- a/main.c
+++ b/main.c
@@ -1,7 +1,7 @@
 /*-------------------------------- FILE INFO ---------------------------------*/
 /* Filename           : main.c                                                */
 /*                                                                            */
-/* main file to test repeat_hello_world interface                             */
+/* main file for for flashing/testing repeat_hello_world interface on mcu     */
 /*                                                                            */
 /*----------------------------------------------------------------------------*/
 

--- a/repeat_hello_world/CMakeLists.txt
+++ b/repeat_hello_world/CMakeLists.txt
@@ -5,7 +5,7 @@
 #                                                                              #
 #------------------------------------------------------------------------------#
 target_sources(repeat_hello_world_lib PRIVATE
-    # ADD ALL .c SOURCE FILES HERE
+    # \/ === ADD ALL .c SOURCE FILES HERE === \/
     ${CMAKE_CURRENT_LIST_DIR}/repeat_hello_world.c
 )
 

--- a/repeat_hello_world/tests/CMakeLists.txt
+++ b/repeat_hello_world/tests/CMakeLists.txt
@@ -5,7 +5,7 @@
 #                                                                              #
 #------------------------------------------------------------------------------#
 set(LOCAL_TEST_SOURCES
-    # ADD ALL TEST SOURCE FILES HERE
+    # \/ === ADD ALL TEST SOURCE FILES HERE === \/
     ${CMAKE_CURRENT_SOURCE_DIR}/test_repeat_hello_world.cpp
     ${CMAKE_SOURCE_DIR}/src/repeat_hello_world/repeat_hello_world.c
     ${CMAKE_CURRENT_SOURCE_DIR}/mocks/hello_world/mock_print_hello_world.c


### PR DESCRIPTION
fix CMakeLists.txt file to properly link to hello_world project's library, and highlight all CMake file changes needed for a user creating their own repo